### PR TITLE
Use v2.5.2b as source (fixes version="2.5.2-dev" in build 0)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,11 +7,12 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/mwouts/itables/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: befb0ae8ab6de86c2e725d981e4fde7db1d757eecc7d6e858080beedf45803e9
+  # url: https://github.com/mwouts/itables/archive/refs/tags/v{{ version }}.tar.gz
+  url: https://github.com/mwouts/itables/archive/refs/tags/v2.5.2b.tar.gz
+  sha256: 5e8e3b975a7eff313ac003db8d89dc12b54132c52dbfb93575cc140cb25357fe
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 


### PR DESCRIPTION
The tag v2.5.2 had been applied too early (https://github.com/mwouts/itables/compare/v2.5.2...v2.5.2b), leading to `itables.version="2.5.2-dev"` in build 0. This is fixed by this new build.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
